### PR TITLE
bullet trails rework & crashfix

### DIFF
--- a/classes/Bullet.lua
+++ b/classes/Bullet.lua
@@ -3,7 +3,6 @@ Bullets = {}
 
 function Bullet:new(speed, damage)
     local recoil = love.math.random(-SelectedWeapon.recoil_current, SelectedWeapon.recoil_current)
-
     self.angle = math.atan2(GameCursor.y - PlayerCharacter.y, GameCursor.x - PlayerCharacter.x) +
         recoil * 0.01
     local cos = math.cos(self.angle)
@@ -16,17 +15,20 @@ function Bullet:new(speed, damage)
     self.speed = speed
     self.radius = 1
     self.damage = damage
-    self.trail_frame = 1
+    self.trail_time = 0
+    self.delete = false
 end
 
 function Bullet:update(dt)
+    self.trail_time = self.trail_time + dt
+
     local cos = math.cos(self.angle)
     local sin = math.sin(self.angle)
 
     self.x = self.x + self.speed * cos * dt
     self.y = self.y + self.speed * sin * dt
 
-    local newBulletTrail = BulletTrail(self.px, self.py, self.x, self.y, 30, self.trail_frame)
+    local newBulletTrail = BulletTrail(self.px, self.py, self.x, self.y, self.trail_time)
     table.insert(BulletTrails, newBulletTrail)
 
     self.px = self.x
@@ -34,9 +36,8 @@ function Bullet:update(dt)
 
     if self.x < 0 or self.x > love.graphics.getWidth() or self.y < 0 or self.y > love.graphics.getHeight() then
         self.delete = true
+        return
     end
-
-    self.trail_frame = self.trail_frame + 1
 end
 
 function Bullet:draw()

--- a/classes/BulletTrail.lua
+++ b/classes/BulletTrail.lua
@@ -1,31 +1,42 @@
 BulletTrail = Object:extend()
 BulletTrails = {}
 
-function BulletTrail:new(px, py, x, y, max, frame)
-    self.trail_max = max
-    self.trail_current = 0
+function BulletTrail:new(px, py, x, y, time)
     self.px = px
     self.py = py
     self.x = x
     self.y = y
+    self.duration = 1
+    self.time = time
+    self.current = 0
+    self.offset = 0.015
+
+    self.color = 0
+    self.currentSetter = false
     self.delete = false
-    self.trail_frame = frame
 end
 
-function BulletTrail:update()
-    if self.trail_frame > 0 and self.trail_frame < 10 then
-        self.trail_max = self.trail_frame * 3
-    end
-    if (self.trail_current < self.trail_max) then
-        self.trail_current = self.trail_current + 1
-    else
+function BulletTrail:update(dt)
+    self.current = self.current + (self.duration * dt)
+    if self.current > self.duration then
         self.delete = true
+        return
+    end
+
+    if not self.currentSetter then
+        self.current = self.duration - self.time - self.offset
+        self.currentSetter = true
+    end
+
+    self.color = (((self.duration - self.current) / dt) / (self.time / dt)) * 0.7
+    if self.offset > 0 then
+        self.offset = self.offset - dt
+        self.color = 0.7
     end
 end
 
 function BulletTrail:draw()
-    local color = 0.7 - ((self.trail_current - 1) / self.trail_max) * 0.7
-    love.graphics.setColor(color, color, color)
+    love.graphics.setColor(self.color, self.color, self.color)
     love.graphics.line(self.px, self.py, self.x, self.y)
     love.graphics.setColor(1, 1, 1)
 end

--- a/classes/Cursor.lua
+++ b/classes/Cursor.lua
@@ -15,6 +15,9 @@ function Cursor:update()
     if not Menu then
         local distance = GetDistance(self.x, self.y, PlayerCharacter.x, PlayerCharacter.y)
         self.radius = SelectedWeapon.recoil_current * (distance / 100)
+        if self.radius < self.default_radius then
+            self.radius = self.default_radius
+        end
     end
 end
 

--- a/classes/Enemy.lua
+++ b/classes/Enemy.lua
@@ -17,11 +17,16 @@ function Enemy:new(x, y, hp, speed, damage, rate_of_fire, image)
 end
 
 function Enemy:update(dt)
-    self.angle = math.atan2(PlayerCharacter.y - self.y, PlayerCharacter.x - self.x)
+    if self.current_hp <= 0 then
+        self.delete = true
+        return
+    end
 
+    self.angle = math.atan2(PlayerCharacter.y - self.y, PlayerCharacter.x - self.x)
     local cos = math.cos(self.angle)
     local sin = math.sin(self.angle)
     local distance = GetDistance(self.x, self.y, PlayerCharacter.x, PlayerCharacter.y)
+
     if self.rate_of_fire_timer > 0 then
         self.rate_of_fire_timer = self.rate_of_fire_timer - dt
     end
@@ -31,9 +36,6 @@ function Enemy:update(dt)
     elseif self.rate_of_fire_timer <= 0 then
         PlayerCharacter.current_hp = PlayerCharacter.current_hp - self.damage
         self.rate_of_fire_timer = self.rate_of_fire
-    end
-    if self.current_hp <= 0 then
-        self.delete = true
     end
 end
 

--- a/classes/Weapons.lua
+++ b/classes/Weapons.lua
@@ -29,12 +29,12 @@ end
 
 function Weapons:load()
     Weapons_Array = {}
-    Weapon_instance = Weapons("Pistol", 0.3, 0.75, 12, 5, 5, 0.25, 30, 3500,
+    Weapon_instance = Weapons("Pistol", 0.3, 0.75, 12, 5, 5, 25, 30, 4500,
         love.audio.newSource("static/sfx/glock18.wav", "static"),
         love.audio.newSource("static/sfx/reload_start.wav", "static"),
         love.audio.newSource("static/sfx/reload_end.wav", "static"))
     table.insert(Weapons_Array, Weapon_instance)
-    Weapon_instance = Weapons("SMG", 0.05, 0.75, 30, 5, 1, 0.15, 10, 3500,
+    Weapon_instance = Weapons("SMG", 0.05, 0.75, 30, 5, 1, 15, 10, 4500,
         love.audio.newSource("static/sfx/mp5.wav", "static"),
         love.audio.newSource("static/sfx/reload_start.wav", "static"),
         love.audio.newSource("static/sfx/reload_end.wav", "static"))
@@ -51,7 +51,7 @@ function Weapons:update(dt)
     end
     for _, wpn in ipairs(Weapons_Array) do
         if wpn.recoil_current > 0 then
-            wpn.recoil_current = wpn.recoil_current - wpn.recoil_decay
+            wpn.recoil_current = wpn.recoil_current - (wpn.recoil_decay * dt)
         end
         if wpn.recoil_current < 0 then
             wpn.recoil_current = 0

--- a/main.lua
+++ b/main.lua
@@ -54,8 +54,8 @@ function love.update(dt)
         for i = #Enemies, 1, -1 do
             Enemies[i]:update(dt)
             if Enemies[i].delete then
-                table.remove(Enemies, i)
                 Score = Score + Enemies[i].score
+                table.remove(Enemies, i)
             end
         end
         for i = #Bullets, 1, -1 do


### PR DESCRIPTION
Bullet trails and Weapon recoil decay are now time based instead of frame based. Now the whole game runs the same regardless of FPS.
Less code executed if instance should be deleted in Enemy, Bullets and BulletTrails.
Fix rare crash on enemy kill.
Cursor recoil circle now starts at default radius.
Increased bullet speed.